### PR TITLE
remove unnecessary code

### DIFF
--- a/src/duel/main.cc
+++ b/src/duel/main.cc
@@ -93,11 +93,6 @@ static void ignoreSIGPIPE()
     CHECK(sigaction(SIGPIPE, &act, 0) == 0);
 }
 
-// TODO(uaua): Without this, we cannot link to libSDLmain.a
-#if defined(__CYGWIN__) && defined(main)
-#undef main
-#endif
-
 int main(int argc, char* argv[])
 {
     google::InitGoogleLogging(argv[0]);

--- a/src/gui/screen.cc
+++ b/src/gui/screen.cc
@@ -15,10 +15,6 @@
 #include "base/base.h"
 #include "gui/util.h"
 
-#ifdef __CYGWIN__
-#include <Windows.h>
-#endif
-
 using namespace std;
 
 Screen::Screen(int width, int height, const Box& mainBox) :
@@ -39,13 +35,8 @@ void Screen::init()
     }
 
     char buf[PATH_MAX+1];
-#ifdef __CYGWIN__
-    if (!GetCurrentDirectory(PATH_MAX, buf))
-        PLOG(FATAL) << "buffer is too small for getcwd";
-#else
     if (!getcwd(buf, PATH_MAX))
         PLOG(FATAL) << "buffer is too small for getcwd";
-#endif
 
     char* p = buf;
     while (true) {

--- a/src/tool/arow.cc
+++ b/src/tool/arow.cc
@@ -82,11 +82,6 @@ private:
 
 // ----------------------------------------------------------------------
 
-// TODO(uaua): Without this, we cannot link to libSDLMain.a.
-#if defined(__CYGWIN__) && defined(main)
-#undef main
-#endif
-
 int main()
 {
     const int WIDTH = 32;


### PR DESCRIPTION
[how-to-build-on-cygwin.md](../blob/master/how-to-build-on-cygwin.md) に従ってビルドした場合、
cygwin側が配っているSDLを使うようになったためパスや引数が正常に扱われるようになっていました。
