### PR TITLE
[niina] Make index 'aa' consistent.

### DIFF
--- a/src/cpu/test_lockit/coma.cc
+++ b/src/cpu/test_lockit/coma.cc
@@ -1163,15 +1163,9 @@ int COMAI_HI::hyouka(const int ba3[6][kHeight], int tsumo[], int zenkesi_own, in
         }
     }
 
+    static const int bias[] = {4,4,4,4,4,4, 3,3,3,3,3,3, 2,2,2,2,2, 1,1,1,1,1};
     for (aa = 0; aa < 22; aa++) {
-        if (aa < 6)
-            m_para[aa] = hym[aa] * 10 + 4;
-        else if (aa < 12)
-            m_para[aa + 5] = hym[aa] * 10 + 3;
-        else if (aa < 17)
-            m_para[aa + 5] = hym[aa] * 10 + 2;
-        else if (aa < 22)
-            m_para[aa - 11] = hym[aa] * 10 + 1;
+        m_para[aa] = hym[aa] * 10 + bias[aa];
     }
     return 0;
 }

--- a/src/cpu/test_lockit/cpu.cc
+++ b/src/cpu/test_lockit/cpu.cc
@@ -238,15 +238,15 @@ FrameResponse TestLockitAI::playOneFrame(const FrameRequest& request)
         if (tmp < 6) {
             r_player[0].te_x = tmp + 1;
             r_player[0].te_r = 0;
-        } else if (tmp < 11) {
-            r_player[0].te_x = tmp - 5;
-            r_player[0].te_r = 1;
-        } else if (tmp < 17) {
-            r_player[0].te_x = tmp - 10;
+        } else if (tmp < 12) {
+            r_player[0].te_x = tmp - 6 + 1;
             r_player[0].te_r = 2;
-        } else if (tmp < 22) {
-            r_player[0].te_x = tmp - 15;
+        } else if (tmp < 17) {
+            r_player[0].te_x = tmp - 12 + 1;
             r_player[0].te_r = 3;
+        } else if (tmp < 22) {
+            r_player[0].te_x = tmp - 17 + 1;
+            r_player[0].te_r = 1;
         }
         if (r_player[0].setti_puyo()) {
             r_player[0].zenkesi = 0;


### PR DESCRIPTION
Before this CL, index `aa` was not consistent between `coma.cc` and `cpu.cc`.
This CL drops a branch to translate index values.