### PR TITLE
Deleted unused pipe not to hide STDERR

### DIFF
--- a/src/core/server/connector/connector.cc
+++ b/src/core/server/connector/connector.cc
@@ -43,13 +43,10 @@ unique_ptr<Connector> Connector::create(int playerId, const string& programName)
     // File descriptors.
     int fd_field_status[2];
     int fd_command[2];
-    int fd_cpu_error[2];
 
     if (pipe(fd_field_status) < 0)
         PLOG(FATAL) << "Pipe error. ";
     if (pipe(fd_command) < 0)
-        PLOG(FATAL) << "Pipe error. ";
-    if (pipe(fd_cpu_error) < 0)
         PLOG(FATAL) << "Pipe error. ";
 
     pid_t pid = fork();
@@ -63,7 +60,6 @@ unique_ptr<Connector> Connector::create(int playerId, const string& programName)
         unique_ptr<Connector> connector(new PipeConnector(fd_field_status[1], fd_command[0]));
         close(fd_field_status[0]);
         close(fd_command[1]);
-        close(fd_cpu_error[1]);
 
         return connector;
     }
@@ -73,15 +69,11 @@ unique_ptr<Connector> Connector::create(int playerId, const string& programName)
         PLOG(FATAL) << "Failed to dup2. ";
     if (dup2(fd_command[1], STDOUT_FILENO) < 0)
         PLOG(FATAL) << "Failed to dup2. ";
-    if (dup2(fd_cpu_error[1], STDERR_FILENO) < 0)
-        PLOG(FATAL) << "Failed to dup2. ";
 
     close(fd_field_status[0]);
     close(fd_field_status[1]);
     close(fd_command[0]);
     close(fd_command[1]);
-    close(fd_cpu_error[0]);
-    close(fd_cpu_error[1]);
 
     char filename[] = "Player_";
     filename[6] = '1' + playerId;


### PR DESCRIPTION
When I mistakenly run the command ```./duel/duel ./cpu/sample/sample ./cpu/sample/sampl``` ("e" is missing),
puyoai fails without any error message.

This is caused by pipe and dup2 at https://github.com/puyoai/puyoai/blob/master/src/core/server/connector/connector.cc#L76.
STDERR was trapped by the pipe and not shown on the command line.

I wonder that the pipe `fd_cpu_error` is not used in the parent process, so `fd_cpu_error` can be removed to prevent STDERR from trapping by the pipe.