### PR TITLE
[niina] Introduce simulate function

### DIFF
--- a/src/cpu/test_lockit/field.cc
+++ b/src/cpu/test_lockit/field.cc
@@ -1,8 +1,8 @@
 #include "field.h"
 
 #include <glog/logging.h>
-#include <set>
 
+#include "base/small_int_set.h"
 #include "color.h"
 #include "core/field_constant.h"
 #include "core/score.h"
@@ -331,9 +331,6 @@ TLRensaResult simulate(TLColor field[][kHeight])
     // Assume all puyos are grounded.
     // TODO: add DCHECK to check it.
 
-    int point[6][12] {};
-    int bottom[6] {};
-
     // parameters necessary to compute score
     int chain = 0;
     int long_bonus[TLRensaResult::MAX_RENSA] {};
@@ -342,13 +339,14 @@ TLRensaResult simulate(TLColor field[][kHeight])
     int num_connections[TLRensaResult::MAX_RENSA] {};  // # of groups
     bool quick = false;
     
+    int bottom[6] {};
     bool cont = true;
     while (cont) {
         cont = false;
-        memset(point, 0, sizeof(point));
+        int point[6][12] {};
         int rakkaflg[6] {};
 
-        std::set<TLColor> used_colors;
+        SmallIntSet used_colors;
         // check connections and vanish
         for (int i = 0; i < 6; ++i) {
             for (int j = bottom[i]; j < 12; ++j) {
@@ -364,7 +362,7 @@ TLRensaResult simulate(TLColor field[][kHeight])
 
                         long_bonus[chain] += longBonus(num);
                         num_connected[chain] += num;
-                        used_colors.insert(color);
+                        used_colors.set(color);
                         num_connections[chain]++;
                     }
                 }
@@ -402,8 +400,6 @@ TLRensaResult simulate(TLColor field[][kHeight])
         int chain_bonus = chainBonus(i + 1);
         int color_bonus = colorBonus(num_colors[i]);
         int rate = calculateRensaBonusCoef(chain_bonus, long_bonus[i], color_bonus);
-        if (rate == 0)
-            rate = 1;
         score += num_connected[i] * rate * 10;
         num_vanished += num_connected[i];
     }

--- a/src/cpu/test_lockit/field.cc
+++ b/src/cpu/test_lockit/field.cc
@@ -352,7 +352,7 @@ TLRensaResult simulate(TLColor field[][kHeight])
             for (int j = bottom[i]; j < 12; ++j) {
                 TLColor color = field[i][j];
                 if (color == TLColor::EMPTY)
-                    break;
+                    continue;
                 if (point[i][j] != 1 && isNormalTLColor(color)) {
                     int num = 0;
                     saiki(field, point, i, j, &num, color);

--- a/src/cpu/test_lockit/field.cc
+++ b/src/cpu/test_lockit/field.cc
@@ -384,10 +384,10 @@ TLRensaResult simulate(TLColor field[][kHeight])
                         if (n == 0)
                             bottom[i] = j;
                         n++;
-                        quick = false;
                     } else if (n != 0) {
                         field[i][j - n] = field[i][j];
                         field[i][j] = TLColor::EMPTY;
+                        quick = false;
                     }
                 }
             }

--- a/src/cpu/test_lockit/field.h
+++ b/src/cpu/test_lockit/field.h
@@ -6,9 +6,15 @@
 
 namespace test_lockit {
 
+struct TLRensaResult;
+
 bool isTLFieldEmpty(const TLColor field[6][kHeight]);
 int countNormalColor13(const TLColor f[][kHeight]);
 void copyField(const TLColor src[][kHeight], TLColor dst[][kHeight]);
+
+// simulates a 連鎖 and returns its result.  The argument |field| will be updated
+// to be state of field after the 連鎖.
+TLRensaResult simulate(TLColor field[][kHeight]);
 
 // --------------------------------------------------------------------
 

--- a/src/cpu/test_lockit/field_test.cc
+++ b/src/cpu/test_lockit/field_test.cc
@@ -153,6 +153,22 @@ TEST(FieldTest, simulate_chain)
     EXPECT_EQ(1, result.num_connections[1]);
 }
 
+TEST(FieldTest, simulate_1_duouble)
+{
+    CoreField cf(
+        "..BBBB"
+        "RRRRRR");
+    TLColor field[6][kHeight];
+    toTLField(cf, field);
+
+    TLRensaResult result = simulate(field);
+    EXPECT_EQ(1, result.chains);
+    EXPECT_EQ(600, result.score);
+    EXPECT_EQ(10, result.num_vanished);
+    EXPECT_TRUE(result.quick);
+    EXPECT_EQ(2, result.num_connections[0]);
+}
+
 TEST(FieldTest, simulate_2_double)
 {
     CoreField cf(

--- a/src/cpu/test_lockit/field_test.cc
+++ b/src/cpu/test_lockit/field_test.cc
@@ -4,6 +4,7 @@
 
 #include "core/core_field.h"
 #include "lockit_constant.h"
+#include "rensa_result.h"
 #include "util.h"
 
 namespace test_lockit {
@@ -118,6 +119,57 @@ TEST(FieldTest, settiOjama)
     EXPECT_EQ(TLColor::EMPTY, field[3][13]);
     EXPECT_EQ(TLColor::EMPTY, field[4][13]);
     EXPECT_EQ(TLColor::EMPTY, field[5][13]);
+}
+
+TEST(FieldTest, simulate_basic)
+{
+    CoreField cf("RRRR..");
+    TLColor field[6][kHeight];
+    toTLField(cf, field);
+    
+    TLRensaResult result = simulate(field);
+    EXPECT_EQ(1, result.chains);
+    EXPECT_EQ(40, result.score);
+    EXPECT_EQ(4, result.num_vanished);
+    EXPECT_TRUE(result.quick);
+    EXPECT_EQ(1, result.num_connections[0]);
+}
+
+TEST(FieldTest, simulate_chain)
+{
+    CoreField cf(
+        "..B..."
+        "..BBYB"
+        "RRRRBB");
+    TLColor field[6][kHeight];
+    toTLField(cf, field);
+
+    TLRensaResult result = simulate(field);
+    EXPECT_EQ(2, result.chains);
+    EXPECT_EQ(700, result.score);
+    EXPECT_EQ(10, result.num_vanished);
+    EXPECT_FALSE(result.quick);
+    EXPECT_EQ(1, result.num_connections[0]);
+    EXPECT_EQ(1, result.num_connections[1]);
+}
+
+TEST(FieldTest, simulate_2_double)
+{
+    CoreField cf(
+        ".R...."
+        ".R...."
+        ".RYR.R"
+        "RYYYRR");
+    TLColor field[6][kHeight];
+    toTLField(cf, field);
+
+    TLRensaResult result = simulate(field);
+    EXPECT_EQ(2, result.chains);
+    EXPECT_EQ(680, result.score);
+    EXPECT_EQ(12, result.num_vanished);
+    EXPECT_TRUE(result.quick);
+    EXPECT_EQ(1, result.num_connections[0]);
+    EXPECT_EQ(2, result.num_connections[1]);
 }
 
 }  // namespace test_lockit

--- a/src/cpu/test_lockit/rensa_result.h
+++ b/src/cpu/test_lockit/rensa_result.h
@@ -1,0 +1,27 @@
+#ifndef CPU_TEST_LOCKIT_RENSA_RESULT_H_
+#define CPU_TEST_LOCKIT_RENSA_RESULT_H_
+
+namespace test_lockit {
+
+struct TLRensaResult {
+    static const int MAX_RENSA = 19;
+
+    int chains = 0;
+
+    // total score in a contiguous chains
+    int score = 0;
+
+    // total colored puyos vanshed in a continguous chains
+    int num_vanished = 0;
+
+    // true if the last vanishment drops no puyos
+    bool quick = false;
+
+    // the number of vanishing groups in each 連鎖 step.  The values of
+    // num_connections[i] for i >= chains are not defined
+    int num_connections[MAX_RENSA] {};
+};
+
+}  // namespace test_lockit
+
+#endif  // CPU_TEST_LOCKIT_RENSA_RESULT_H_

--- a/src/cpu/test_lockit/rensa_result.h
+++ b/src/cpu/test_lockit/rensa_result.h
@@ -8,16 +8,16 @@ struct TLRensaResult {
 
     int chains = 0;
 
-    // total score in a contiguous chains
+    // total score in a continuous chains
     int score = 0;
 
-    // total colored puyos vanshed in a continguous chains
+    // total colored puyos vanished in a continuous chains
     int num_vanished = 0;
 
     // true if the last vanishment drops no puyos
     bool quick = false;
 
-    // the number of vanishing groups in each 連鎖 step.  The values of
+    // the number of vanishing groups in each chain step.  The values of
     // num_connections[i] for i >= chains are not defined
     int num_connections[MAX_RENSA] {};
 };


### PR DESCRIPTION
Made `simulate()` function to simplify `field.cc` and `coma.cc`.
And this patch set also introduce a struct `TLRensaResult` to pass usable values at once.

`simulate()` is not called in this patch.

BUG=#125 