### PR TITLE
Bug fix: added necessary #include<cmath> to avoid build failure.

### DIFF
--- a/src/cpu/peria/evaluator.cc
+++ b/src/cpu/peria/evaluator.cc
@@ -1,5 +1,6 @@
 #include "evaluator.h"
 
+#include <cmath>
 #include <algorithm>
 #include <numeric>
 #include <sstream>


### PR DESCRIPTION
Build fails in my enviroment because of missing `#include<cmath>` in `peria/evaluator.cc`.