### PR TITLE
Fix rensa information

### DIFF
--- a/src/core/server/commentator.cc
+++ b/src/core/server/commentator.cc
@@ -151,11 +151,6 @@ void Commentator::runLoop()
 
 void Commentator::update(int pi, const CoreField& field, const KumipuyoSeq& kumipuyoSeq)
 {
-    for (const Kumipuyo& kp : kumipuyoSeq) {
-        if (kp.axis == PuyoColor::EMPTY || kp.child == PuyoColor::EMPTY)
-            return;
-    }
-
     // 1. Check field is firing a rensa.
     {
         CoreField f(field);
@@ -178,9 +173,9 @@ void Commentator::update(int pi, const CoreField& field, const KumipuyoSeq& kumi
 
     // 2. Check Tsubushi chain
     {
-        KumipuyoSeq kp(kumipuyoSeq);
-        if (3 < kp.size())
-            kp.resize(3);
+        KumipuyoSeq kp;
+        for (int i = 0; i < min(3, kumipuyoSeq.size()) && kumipuyoSeq.get(i).isValid(); ++i)
+            kp.add(kumipuyoSeq.get(i));
 
         pair<int, double> bestTsubushiScore = make_pair(100, 0.0); // # of hand & score. Smaller is better.
         IgnitionRensaResult ignitionRensaResult;


### PR DESCRIPTION
Comentator::update() skips update of rensa information if kumipuyoSeq contains invalid Kumipuyo.
Program crashes in Plan::iterateAvailablePlans() if kp contains invalid Kumipuyo, so I made kp use valid Kumipuyos.