### PR TITLE
Use 4 random colors in first 3 kumipuyos

### DIFF
--- a/src/cpu/peria/quick_full.cc
+++ b/src/cpu/peria/quick_full.cc
@@ -176,7 +176,7 @@ class QuickFullAI : public AI {
         break;
 
       KumipuyoSeq vseq = seq;  // 'v' stands for "virtual"
-      vseq.append(generateRandomSequenceWithSeed(frame_id + num_simulate));
+      vseq.append(generateRandomSequenceWithSeed(frame_id + num_simulate).subsequence(3));
       int search_turns = std::max((FLAGS_max_puyos - field.countPuyos()) / 2,
                                   FLAGS_min_turn);
       ++num_simulate;


### PR DESCRIPTION
First 3 kumipuyos in sequence which generateRandomSequence*() returns contains 3 colors at most. This is Puyo2 rule.
I recommend to ignoreing first 3 kumipuyos.