### PR TITLE
Add hash struct of BitField/CoreField

### DIFF
--- a/src/core/bit_field.h
+++ b/src/core/bit_field.h
@@ -310,6 +310,19 @@ void BitField::calculateHeight(int heights[FieldConstant::MAP_WIDTH]) const
    _mm_store_si128(reinterpret_cast<__m128i*>(heights + 4), _mm_unpackhi_epi16(count, zero));
 }
 
+namespace std {
+
+template<>
+struct hash<BitField>
+{
+    size_t operator()(const BitField& bf) const
+    {
+        return bf.hash();
+    }
+};
+
+}
+
 #include "bit_field_inl.h"
 
 #endif // CORE_BIT_FIELD_H_

--- a/src/core/core_field.h
+++ b/src/core/core_field.h
@@ -282,4 +282,17 @@ void CoreField::removePuyoFrom(int x)
     unsafeSet(x, heights_[x]--, PuyoColor::EMPTY);
 }
 
+namespace std {
+
+template<>
+struct hash<CoreField>
+{
+    size_t operator()(const CoreField& cf) const
+    {
+        return cf.hash();
+    }
+};
+
+}
+
 #endif


### PR DESCRIPTION
For using unordered_* directly.
like unordered_set\<CoreField\>