### PR TITLE
Extend iterateAvailablePlans to handle events.

### DIFF
--- a/src/core/algorithm/plan.cc
+++ b/src/core/algorithm/plan.cc
@@ -95,12 +95,21 @@ void iterateAvailablePlansInternal(CoreField field,
         n = 10;
     }
 
-    if (eventIndex < events.size()) {
-        const Plan::Event& event = events[eventIndex];
-        if (event.type == Plan::Event::Type::FALL_OJAMA_ROWS && event.frames < totalFrames) {
-            totalFrames += field.fallOjama(event.value);
-            ++eventIndex;
+    {
+        // Now we work only for FALL_OJAMA_PUYOS events.
+        int ojama_rows = 0;
+        for (; eventIndex < events.size() && events[eventIndex].frames < totalFrames; ++eventIndex) {
+            const Plan::Event& event = events[eventIndex];
+            switch (event.type) {
+            case Plan::Event::Type::FALL_OJAMA_ROWS:
+                ojama_rows += event.value;
+                break;
+            default:
+                CHECK(false) << "Unknown event type";
+            }
         }
+        if (ojama_rows)
+            totalFrames += field.fallOjama(ojama_rows);
         if (!field.isEmpty(3, 12))
             return;
     }

--- a/src/core/algorithm/plan.cc
+++ b/src/core/algorithm/plan.cc
@@ -96,7 +96,8 @@ void iterateAvailablePlansInternal(CoreField field,
     }
 
     {
-        // Now we work only for FALL_OJAMA_PUYOS events.
+        // Multiple fall-ojama events are merged if they are unused and their frame's are past.
+        // TODO: At most 5 rows of Ojama fall at once.  Remained ojama will fall later.
         int ojama_rows = 0;
         for (; eventIndex < events.size() && events[eventIndex].frames < totalFrames; ++eventIndex) {
             const Plan::Event& event = events[eventIndex];

--- a/src/core/algorithm/plan.h
+++ b/src/core/algorithm/plan.h
@@ -15,6 +15,22 @@ class RefPlan;
 
 class Plan {
 public:
+    // Event which may happen during the iteration.
+    // Extend Type if you want to use more types of events.
+    struct Event {
+        enum Type {
+            FALL_OJAMA_ROWS,
+        };
+
+        // This figures when this event will happen. 0 figures the frameId when a API is called.
+        int frames;
+
+        // Meaning of this variable depends on which type of event.
+        int value;
+
+        Type type;
+    };
+
     Plan() {}
     Plan(const CoreField& field, const std::vector<Decision>& decisions,
          const RensaResult& rensaResult, int numChigiri, int framesToIgnite, int lastDropFrames,
@@ -29,10 +45,14 @@ public:
     typedef std::function<void (const RefPlan&)> IterationCallback;
     // if |kumipuyos.size()| < |depth|, we will add extra kumipuyo.
     static void iterateAvailablePlans(const CoreField&, const KumipuyoSeq&, int depth, const IterationCallback&);
+    static void iterateAvailablePlansWithEvents(const CoreField&, const KumipuyoSeq&, int depth,
+                                                const std::vector<Event>& events, const IterationCallback&);
 
     typedef std::function<void (const CoreField&, const std::vector<Decision>&,
                                 int numChigiri, int framesToIgnite, int lastDropFrames, bool shouldFire)> RensaIterationCallback;
     static void iterateAvailablePlansWithoutFiring(const CoreField&, const KumipuyoSeq&, int depth, const RensaIterationCallback&);
+    static void iterateAvailablePlansWithoutFiringWithEvents(const CoreField&, const KumipuyoSeq&, int depth,
+                                                             const std::vector<Event>& events, const RensaIterationCallback&);
 
     const CoreField& field() const { return field_; }
 

--- a/src/core/algorithm/plan.h
+++ b/src/core/algorithm/plan.h
@@ -18,17 +18,22 @@ public:
     // Event which may happen during the iteration.
     // Extend Type if you want to use more types of events.
     struct Event {
-        enum Type {
+        enum class Type {
             FALL_OJAMA_ROWS,
         };
+
+        static Event fallOjamaRowsEvent(int frame, int rows)
+        {
+            return Event { Type::FALL_OJAMA_ROWS, frame, rows };
+        }
+
+        Type type;
 
         // This figures when this event will happen. 0 figures the frameId when a API is called.
         int frames;
 
         // Meaning of this variable depends on which type of event.
         int value;
-
-        Type type;
     };
 
     Plan() {}
@@ -45,12 +50,14 @@ public:
     typedef std::function<void (const RefPlan&)> IterationCallback;
     // if |kumipuyos.size()| < |depth|, we will add extra kumipuyo.
     static void iterateAvailablePlans(const CoreField&, const KumipuyoSeq&, int depth, const IterationCallback&);
+    // We assume events are sorted in increasing order of frames.
     static void iterateAvailablePlansWithEvents(const CoreField&, const KumipuyoSeq&, int depth,
                                                 const std::vector<Event>& events, const IterationCallback&);
 
     typedef std::function<void (const CoreField&, const std::vector<Decision>&,
                                 int numChigiri, int framesToIgnite, int lastDropFrames, bool shouldFire)> RensaIterationCallback;
     static void iterateAvailablePlansWithoutFiring(const CoreField&, const KumipuyoSeq&, int depth, const RensaIterationCallback&);
+    // We assume events are sorted in increasing order of frames.
     static void iterateAvailablePlansWithoutFiringWithEvents(const CoreField&, const KumipuyoSeq&, int depth,
                                                              const std::vector<Event>& events, const RensaIterationCallback&);
 

--- a/src/core/algorithm/plan_test.cc
+++ b/src/core/algorithm/plan_test.cc
@@ -70,14 +70,45 @@ TEST(Plan, iterateAvailablePlansWithEvents)
 
     // With |events|, 2 rows of Ojama will fall just after 1st control,
     // so we cannot vanish puyos, because of ojama wall.
-    std::vector<Plan::Event> events = {Plan::Event {1, 2, Plan::Event::Type::FALL_OJAMA_ROWS}};
+    std::vector<Plan::Event> events = {Plan::Event::fallOjamaRowsEvent(1, 2)};
     found = false;
     Plan::iterateAvailablePlansWithEvents(field, seq, 2, events, callback);
     EXPECT_FALSE(found);
 
     // With |lateEvents|, Ojama will fall 1000 frames later.  It means we can control
     // 2 Kumipuyos before Ojama fall, and we can vanish puyos.
-    std::vector<Plan::Event> lateEvents = {Plan::Event {1000, 2, Plan::Event::Type::FALL_OJAMA_ROWS}};
+    std::vector<Plan::Event> lateEvents = {Plan::Event::fallOjamaRowsEvent(1000, 2)};
+    found = false;
+    Plan::iterateAvailablePlansWithEvents(field, seq, 2, lateEvents, callback);
+    EXPECT_TRUE(found);
+}
+
+TEST(Plan, iterateAvailablePlansWithMultipleEvents)
+{
+    CoreField field;
+    KumipuyoSeq seq("BBBB");
+    bool found = false;
+    
+    auto callback = [&found](const RefPlan& p) {
+        if (p.isRensaPlan())
+            found = true;
+    };
+
+    // Two rows of ojama in total will fall before 2nd control.
+    std::vector<Plan::Event> events = {
+        Plan::Event::fallOjamaRowsEvent(1, 1),
+        Plan::Event::fallOjamaRowsEvent(10, 1)
+    };
+    found = false;
+    Plan::iterateAvailablePlansWithEvents(field, seq, 2, events, callback);
+    EXPECT_FALSE(found);
+
+    // A row of ojama fall before 2nd control, and another row of
+    // ojama will fall after 2nd control.
+    std::vector<Plan::Event> lateEvents = {
+        Plan::Event::fallOjamaRowsEvent(1, 1),
+        Plan::Event::fallOjamaRowsEvent(1000, 1)
+    };
     found = false;
     Plan::iterateAvailablePlansWithEvents(field, seq, 2, lateEvents, callback);
     EXPECT_TRUE(found);

--- a/src/core/algorithm/plan_test.cc
+++ b/src/core/algorithm/plan_test.cc
@@ -57,6 +57,32 @@ TEST(Plan, iterateAvailablePlansWithRensa)
     EXPECT_EQ(0, plan.framesToIgnite());
 }
 
+TEST(Plan, iterateAvailablePlansWithEvents)
+{
+    CoreField field;
+    KumipuyoSeq seq("BBBB");
+    bool found = false;
+
+    auto callback = [&found](const RefPlan& p) {
+        if (p.isRensaPlan())
+            found = true;
+    };
+
+    // With |events|, 2 rows of Ojama will fall just after 1st control,
+    // so we cannot vanish puyos, because of ojama wall.
+    std::vector<Plan::Event> events = {Plan::Event {1, 2, Plan::Event::Type::FALL_OJAMA_ROWS}};
+    found = false;
+    Plan::iterateAvailablePlansWithEvents(field, seq, 2, events, callback);
+    EXPECT_FALSE(found);
+
+    // With |lateEvents|, Ojama will fall 1000 frames later.  It means we can control
+    // 2 Kumipuyos before Ojama fall, and we can vanish puyos.
+    std::vector<Plan::Event> lateEvents = {Plan::Event {1000, 2, Plan::Event::Type::FALL_OJAMA_ROWS}};
+    found = false;
+    Plan::iterateAvailablePlansWithEvents(field, seq, 2, lateEvents, callback);
+    EXPECT_TRUE(found);
+}
+
 TEST(Plan, numChigiri)
 {
     CoreField cf("  O   ");


### PR DESCRIPTION
Using the new APIs, we will be able to fall rows of ojama puyos during the iterations.
Performance regression seems small enough to be ignored.

Performance tests:
before
```
[ RUN      ] PlanPerformanceTest.Filled23
        N = 10
      min = 3359484
      max = 5519563
  average = 3.85792e+06
deviation = 645352
[       OK ] PlanPerformanceTest.Filled23 (14 ms)
[ RUN      ] PlanPerformanceTest.Empty24
        N = 10
      min = 362338851
      max = 373247613
  average = 3.66979e+08
deviation = 3.17033e+06
[       OK ] PlanPerformanceTest.Empty24 (1362 ms)
[ RUN      ] PlanPerformanceTest.Filled24
        N = 10
      min = 428158605
      max = 468231909
  average = 4.35227e+08
deviation = 1.13371e+07
[       OK ] PlanPerformanceTest.Filled24 (1615 ms)
[----------] 6 tests from PlanPerformanceTest (3138 ms total)
```

after
```
[ RUN      ] PlanPerformanceTest.Filled23
        N = 10
      min = 3349941
      max = 4855311
  average = 3.77028e+06
deviation = 570955
[       OK ] PlanPerformanceTest.Filled23 (14 ms)
[ RUN      ] PlanPerformanceTest.Empty24
        N = 10
      min = 362581797
      max = 414601665
  average = 3.7237e+08
deviation = 1.66012e+07
[       OK ] PlanPerformanceTest.Empty24 (1382 ms)
[ RUN      ] PlanPerformanceTest.Filled24
        N = 10
      min = 427249824
      max = 438439887
  average = 4.31608e+08
deviation = 3.39203e+06
[       OK ] PlanPerformanceTest.Filled24 (1603 ms)
[----------] 6 tests from PlanPerformanceTest (3148 ms total)
```