### PR TITLE
Supress logging all receive/send frame information

### DIFF
--- a/src/core/client/connector/client_connector.cc
+++ b/src/core/client/connector/client_connector.cc
@@ -41,7 +41,8 @@ bool ClientConnector::receive(FrameRequest* frameRequest)
 
     payload[header.size] = '\0';
 
-    LOG(INFO) << "RECEIVED: " << payload;
+    // TODO: Use LOG(INFO) for informative frames.
+    VLOG(1) << "RECEIVED: " << payload;
     *frameRequest = FrameRequest::parsePayload(payload, header.size);
     return true;
 }
@@ -56,5 +57,8 @@ void ClientConnector::send(const FrameResponse& resp)
     writeExactly(s.data(), s.size());
     flush();
 
-    LOG(INFO) << "SEND: " << s;
+    if (resp.isValid())
+      LOG(INFO) << "SEND: " << s;
+    else
+      VLOG(1) << "SEND: " << s;
 }


### PR DESCRIPTION
Logging all information for send/receive frame information is noisy and make log files huge.
This PR replaces `LOG(INFO)` with `VLOG(1)` in `client_connector.cc` to suppress most non-informative information.

1. Suppressed information can be logged with --v=1 option.
2. Keep logging all sending information with controls.
