### PR TITLE
Make method names consistent.

### DIFF
--- a/src/core/client/ai/drop_decision.h
+++ b/src/core/client/ai/drop_decision.h
@@ -19,7 +19,7 @@ public:
 
     void setMessage(const std::string& msg) { message_ = msg; }
 
-    bool valid() const { return decision_.isValid(); }
+    bool isValid() const { return decision_.isValid(); }
 
 private:
     Decision decision_;

--- a/src/cpu/mayah/yukina_ai.cc
+++ b/src/cpu/mayah/yukina_ai.cc
@@ -93,7 +93,7 @@ DropDecision YukinaAI::think(int frame_id, const CoreField& field, const Kumipuy
 
     double beginTimeSec = currentTime();
     DropDecision dd = thinkByThinker(frame_id, field, kumipuyo_seq, me, enemy, fast);
-    if (dd.valid()) {
+    if (dd.isValid()) {
         double endTimeSec = currentTime();
         double durationSec = endTimeSec - beginTimeSec;
 


### PR DESCRIPTION
`DropDecision` class used `valid()` for its validation, while other classes under `core/` use `isValid()`.
This change clears this inconsistency.