### PR TITLE
Make 1 tsumo acceptable in decision book.

### DIFF
--- a/src/core/pattern/decision_book.cc
+++ b/src/core/pattern/decision_book.cc
@@ -40,20 +40,10 @@ Decision DecisionBookField::nextDecision(const CoreField& cf, const KumipuyoSeq&
         return Decision();
 
     // Now it is guaranteed that field is matched.
-
-    // Check sequence with 1 Tsumo.
     const Kumipuyo& kp1 = seq.get(0);
-    for (const auto& entry : decisions1_) {
-        if (matchNext(&matcher, entry.first, kp1))
-            return entry.second;
-        if (kp1.isRep())
-            continue;
-        if (matchNext(&matcher, entry.first, kp1.reverse()))
-            return entry.second.reverse();
-    }
+    const Kumipuyo& kp2 = seq.get(1);
 
     // Check sequence with 2 Tsumos.
-    const Kumipuyo& kp2 = seq.get(1);
     for (const auto& entry : decisions2_) {
         if (matchNext(&matcher, entry.first, kp1, kp2))
             return entry.second;
@@ -66,6 +56,16 @@ Decision DecisionBookField::nextDecision(const CoreField& cf, const KumipuyoSeq&
         if (matchNext(&matcher, entry.first, kp1.reverse(), kp2))
             return entry.second.reverse();
         if (!kp2.isRep() && matchNext(&matcher, entry.first, kp1.reverse(), kp2.reverse()))
+            return entry.second.reverse();
+    }
+
+    // Check sequence with 1 Tsumo.
+    for (const auto& entry : decisions1_) {
+        if (matchNext(&matcher, entry.first, kp1))
+            return entry.second;
+        if (kp1.isRep())
+            continue;
+        if (matchNext(&matcher, entry.first, kp1.reverse()))
             return entry.second.reverse();
     }
 

--- a/src/core/pattern/decision_book.h
+++ b/src/core/pattern/decision_book.h
@@ -19,15 +19,20 @@ class KumipuyoSeq;
 class DecisionBookField {
 public:
     DecisionBookField(const std::vector<std::string>& field,
-                      std::map<std::string, Decision>&& decisions);
+                      std::map<std::string, Decision>&& decisions1,
+                      std::map<std::string, Decision>&& decisions2);
 
     Decision nextDecision(const CoreField&, const KumipuyoSeq&) const;
 
 private:
+    bool matchNext(BijectionMatcher*, const std::string& nextPattern, const Kumipuyo& next1) const;
     bool matchNext(BijectionMatcher*, const std::string& nextPattern, const Kumipuyo& next1, const Kumipuyo& next2) const;
 
     FieldPattern pattern_;
-    std::map<std::string, Decision> decisions_;
+    // Decisions decided with 1 Tsumo.
+    std::map<std::string, Decision> decisions1_;
+    // Decisions decided with 2 Tsumos.
+    std::map<std::string, Decision> decisions2_;
 };
 
 // DecisionBook is a book to return a fixed Decision from the given field and kumipuyo sequence.

--- a/src/core/pattern/decision_book_test.cc
+++ b/src/core/pattern/decision_book_test.cc
@@ -7,7 +7,9 @@
 
 using namespace std;
 
-static const char TEST_BOOK[] =
+namespace {
+
+const char TEST_BOOK[] =
     "[[book]]\n"
     "field = []\n"
     "AAAA = [3, 2]\n"
@@ -39,57 +41,84 @@ static const char TEST_BOOK[] =
     "    \".B....\",\n"
     "    \".A....\"\n"
     "]\n"
-    "ABAB = [3, 0]\n";
+    "ABAB = [3, 0]\n"
+    "\n"
+    "[[book]]\n"
+    "field = [\n"
+    "    \"AA..AA\"\n"
+    "]\n"
+    "AA = [3, 1]\n";
+}  // namespace
 
-TEST(DecisionBookTest, nextDecision1)
+class DecisionBookTest : public testing::Test {
+ public:
+  void SetUp() override
+  {
+    ASSERT_TRUE(m_book.loadFromString(TEST_BOOK));
+  }
+
+  DecisionBook& book() { return m_book; }
+
+ private:
+  DecisionBook m_book;
+};
+
+TEST_F(DecisionBookTest, nextDecisionNotInBook)
 {
-    DecisionBook book;
-    ASSERT_TRUE(book.loadFromString(TEST_BOOK));
+    CoreField cf;
+    KumipuyoSeq seq("RRBG");
 
+    EXPECT_FALSE(book().nextDecision(cf, seq).isValid());
+}
+
+TEST_F(DecisionBookTest, nextDecisionWithOneTsumo)
+{
+    CoreField cf("RR..RR");
+    KumipuyoSeq seq("RR");
+
+    EXPECT_EQ(Decision(3, 1), book().nextDecision(cf, seq));
+}
+
+TEST_F(DecisionBookTest, nextDecision1)
+{
     CoreField cf;
     KumipuyoSeq seq("RRRRRRGG");
 
-    EXPECT_EQ(Decision(3, 2), book.nextDecision(cf, seq));
+    EXPECT_EQ(Decision(3, 2), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(3, 2), seq.front());
     seq.dropFront();
 
-    EXPECT_EQ(Decision(5, 2), book.nextDecision(cf, seq));
+    EXPECT_EQ(Decision(5, 2), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(5, 2), seq.front());
     seq.dropFront();
 
-    EXPECT_FALSE(book.nextDecision(cf, seq).isValid());
+    EXPECT_FALSE(book().nextDecision(cf, seq).isValid());
 }
 
-TEST(DecisionBookTest, nextDecision2)
+TEST_F(DecisionBookTest, nextDecision2)
 {
-    DecisionBook book;
-    ASSERT_TRUE(book.loadFromString(TEST_BOOK));
-
     CoreField cf;
     KumipuyoSeq seq("RRBBGG");
 
-    EXPECT_EQ(Decision(3, 3), book.nextDecision(cf, seq));
+    EXPECT_EQ(Decision(3, 3), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(3, 3), seq.front());
     seq.dropFront();
 
-    EXPECT_EQ(Decision(3, 3), book.nextDecision(cf, seq));
+    EXPECT_EQ(Decision(3, 3), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(3, 3), seq.front());
     seq.dropFront();
 }
 
-TEST(DecisionBookTest, nextDecision3)
+TEST_F(DecisionBookTest, nextDecision3)
 {
-    DecisionBook book;
-    ASSERT_TRUE(book.loadFromString(TEST_BOOK));
-
     CoreField cf;
     KumipuyoSeq seq("RBRBBR");
 
-    EXPECT_EQ(Decision(2, 2), book.nextDecision(cf, seq));
+    EXPECT_EQ(Decision(2, 2), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(2, 2), seq.front());
     seq.dropFront();
 
-    EXPECT_EQ(Decision(3, 2), book.nextDecision(cf, seq));
+    EXPECT_EQ(Decision(3, 2), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(3, 2), seq.front());
     seq.dropFront();
 }

--- a/src/core/pattern/decision_book_test.cc
+++ b/src/core/pattern/decision_book_test.cc
@@ -24,11 +24,8 @@ const char TEST_BOOK[] =
     "    \"..A...\",\n"
     "    \"..A...\"\n"
     "]\n"
+    "AA = [3, 0]\n"
     "AAAA = [5, 2]\n"
-    "AAAB = [3, 0]\n"
-    "AAAC = [3, 0]\n"
-    "AABB = [3, 0]\n"
-    "AABC = [3, 0]\n"
     "\n"
     "[[book]]\n"
     "field = [\n"
@@ -41,13 +38,7 @@ const char TEST_BOOK[] =
     "    \".B....\",\n"
     "    \".A....\"\n"
     "]\n"
-    "ABAB = [3, 0]\n"
-    "\n"
-    "[[book]]\n"
-    "field = [\n"
-    "    \"AA..AA\"\n"
-    "]\n"
-    "AA = [3, 1]\n";
+    "ABAB = [3, 0]\n";
 }  // namespace
 
 class DecisionBookTest : public testing::Test {
@@ -73,10 +64,17 @@ TEST_F(DecisionBookTest, nextDecisionNotInBook)
 
 TEST_F(DecisionBookTest, nextDecisionWithOneTsumo)
 {
-    CoreField cf("RR..RR");
-    KumipuyoSeq seq("RR");
+    CoreField cf;
+    KumipuyoSeq seq("RRRRGG");
 
-    EXPECT_EQ(Decision(3, 1), book().nextDecision(cf, seq));
+    EXPECT_EQ(Decision(3, 2), book().nextDecision(cf, seq));
+    cf.dropKumipuyo(Decision(3, 2), seq.front());
+    seq.dropFront();
+
+    // We have no entry to match with "RRGG", so "RR" is used.
+    EXPECT_EQ(Decision(3, 0), book().nextDecision(cf, seq));
+    cf.dropKumipuyo(Decision(3, 0), seq.front());
+    seq.dropFront();
 }
 
 TEST_F(DecisionBookTest, nextDecision1)
@@ -88,6 +86,7 @@ TEST_F(DecisionBookTest, nextDecision1)
     cf.dropKumipuyo(Decision(3, 2), seq.front());
     seq.dropFront();
 
+    // 2 Tsumo's control is prioritized to 1 Tsumo's control.
     EXPECT_EQ(Decision(5, 2), book().nextDecision(cf, seq));
     cf.dropKumipuyo(Decision(5, 2), seq.front());
     seq.dropFront();


### PR DESCRIPTION
This CL makes DecisionBook accept 1 kumi-puyo sequences in keys.

When we have a template depending on the controlling kumi-puyos, we had to write like

```
ABAA = [3, 2]
ABAB = [3, 2]
ABAC = [3, 2]
ABBB = [3, 2]
 :
```

but listing up all 2 kumi-puyo sequences is not readable nor practical. In stead,
this CL enables us to write it as

```
AB = [3, 2]
```
