### PR TITLE
Fix broken build.

### DIFF
--- a/src/cpu/peria/pattern_test.cc
+++ b/src/cpu/peria/pattern_test.cc
@@ -16,7 +16,7 @@ namespace peria {
 class TestableDynamicPatternBook : public DynamicPatternBook {
  public:
   TestableDynamicPatternBook(const std::string& str) {
-    ASSERT_TRUE(loadFromString(str));
+    EXPECT_TRUE(loadFromString(str));
   }
   size_t size() { return book_.size(); }
   Book::iterator find(const FieldBits& key) { return book_.find(key); }


### PR DESCRIPTION
ASSERT* can't be used in a constructor.
https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#my-compiler-complains-that-a-constructor-or-destructor-cannot-return-a-value-whats-going-on